### PR TITLE
IniFile: Added constructors that take filenames as C strings.

### DIFF
--- a/ModLoaderCommon/IniFile.cpp
+++ b/ModLoaderCommon/IniFile.cpp
@@ -261,7 +261,6 @@ IniFile::IniFile(const string &filename)
 	FILE *f = fopen(filename.c_str(), "r");
 	if (!f)
 		return;
-
 	load(f);
 	fclose(f);
 }
@@ -271,7 +270,24 @@ IniFile::IniFile(const wstring &filename)
 	FILE *f = _wfopen(filename.c_str(), L"r");
 	if (!f)
 		return;
+	load(f);
+	fclose(f);
+}
 
+IniFile::IniFile(const char *filename)
+{
+	FILE *f = fopen(filename, "r");
+	if (!f)
+		return;
+	load(f);
+	fclose(f);
+}
+
+IniFile::IniFile(const wchar_t *filename)
+{
+	FILE *f = _wfopen(filename, L"r");
+	if (!f)
+		return;
 	load(f);
 	fclose(f);
 }

--- a/ModLoaderCommon/IniFile.hpp
+++ b/ModLoaderCommon/IniFile.hpp
@@ -62,9 +62,11 @@ class IniGroup
 class IniFile
 {
 	public:
-		IniFile(const std::string &filename);
-		IniFile(const std::wstring &filename);
-		IniFile(FILE *f);
+		explicit IniFile(const std::string &filename);
+		explicit IniFile(const std::wstring &filename);
+		explicit IniFile(const char *filename);
+		explicit IniFile(const wchar_t *filename);
+		explicit IniFile(FILE *f);
 		~IniFile();
 
 		IniGroup *getGroup(const std::string &section);


### PR DESCRIPTION
This will allow us to reduce allocations in sadx-mod-loader by using snprintf() and/or swprintf() with a stack buffer instead of concatenating multiple strings and/or wstrings.

This PR is a prerequisite for the aforementioned sadx-mod-loader changes.