### PR TITLE
Add LengthOfArray and SizeOfArray

### DIFF
--- a/ModLoaderCommon/IniFile.cpp
+++ b/ModLoaderCommon/IniFile.cpp
@@ -6,6 +6,7 @@
 #include "stdafx.h"
 #include "IniFile.hpp"
 #include "TextConv.hpp"
+#include "Utils.hpp"
 
 // Needed for CP_UTF8 if stdafx.h doesn't have windows.h.
 #ifndef WIN32_LEAN_AND_MEAN
@@ -16,6 +17,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
+#include <list>
 using std::transform;
 using std::string;
 using std::unordered_map;

--- a/ModLoaderCommon/ModLoaderCommon.vcxproj
+++ b/ModLoaderCommon/ModLoaderCommon.vcxproj
@@ -84,6 +84,7 @@
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="TextConv.hpp" />
+    <ClInclude Include="Utils.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CodeParser.cpp" />

--- a/ModLoaderCommon/ModLoaderCommon.vcxproj.filters
+++ b/ModLoaderCommon/ModLoaderCommon.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClInclude Include="FileSystem.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Utils.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">

--- a/ModLoaderCommon/Utils.hpp
+++ b/ModLoaderCommon/Utils.hpp
@@ -1,0 +1,53 @@
+#ifndef UTILS_HPP
+#define UTILS_HPP
+
+// Utility Functions
+#ifdef __cplusplus
+// C++ version.
+
+/**
+* Get the number of elements in an array.
+* @return Number of elements in the array.
+*/
+template <typename T, size_t N>
+static inline size_t LengthOfArray(const T(&)[N])
+{
+	return N;
+}
+
+/**
+* Get the size of an array.
+* @return Size of the array, in bytes.
+*/
+template <typename T, size_t N>
+static inline size_t SizeOfArray(const T(&)[N])
+{
+	return N * sizeof(T);
+}
+#else
+
+// C version.
+
+/**
+* Number of elements in an array.
+*
+* Includes a static check for pointers to make sure
+* a dynamically-allocated array wasn't specified.
+* Reference: http://stackoverflow.com/questions/8018843/macro-definition-array-size
+*/
+#define LengthOfArray(x) \
+	((int)(((sizeof(x) / sizeof(x[0]))) / \
+		(size_t)(!(sizeof(x) % sizeof(x[0])))))
+
+#define SizeOfArray(x) sizeof(x)
+
+#endif
+
+// Macros for functions that need both an array
+// and the array length or size.
+#define arrayptrandlength(data) data, LengthOfArray(data)
+#define arraylengthandptr(data) LengthOfArray(data), data
+#define arrayptrandsize(data) data, SizeOfArray(data)
+#define arraysizeandptr(data) SizeOfArray(data), data
+
+#endif /* UTILS_HPP */


### PR DESCRIPTION
LengthOfArray was being used in IniGroup::setIntRadix on non-MSVC compilers, but it wasn't previously implemented.

The implementation itself was taken from skc-mod-loader.