### PR TITLE
Upgrade to .NET Framework 4.8, various fixes

### DIFF
--- a/ModManagerCommon/Forms/LoaderDownloadDialog.cs
+++ b/ModManagerCommon/Forms/LoaderDownloadDialog.cs
@@ -84,7 +84,7 @@ namespace ModManagerCommon.Forms
 								OnDownloadProgress(this, downloadArgs);
 								if (downloadArgs.Cancel)
 								{
-									((WebClient)sender).CancelAsync();
+									client.CancelAsync();
 								}
 							}
 

--- a/ModManagerCommon/Forms/ProgressDialog.Designer.cs
+++ b/ModManagerCommon/Forms/ProgressDialog.Designer.cs
@@ -28,75 +28,74 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.progressBar = new System.Windows.Forms.ProgressBar();
-			this.labelTask = new System.Windows.Forms.Label();
-			this.labelStep = new System.Windows.Forms.Label();
-			this.buttonCancel = new System.Windows.Forms.Button();
-			this.SuspendLayout();
+            this.progressBar = new System.Windows.Forms.ProgressBar();
+            this.labelTask = new System.Windows.Forms.Label();
+            this.labelStep = new System.Windows.Forms.Label();
+            this.buttonCancel = new System.Windows.Forms.Button();
+            this.SuspendLayout();
             // 
             // progressBar
             // 
-            this.progressBar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.progressBar.Location = new System.Drawing.Point(12, 39);
-			this.progressBar.Maximum = 2147483646;
-			this.progressBar.Name = "progressBar";
-			this.progressBar.Size = new System.Drawing.Size(344, 23);
-			this.progressBar.Step = 1;
-			this.progressBar.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
-			this.progressBar.TabIndex = 3;
-			// 
-			// labelTask
-			// 
-			this.labelTask.AutoEllipsis = true;
-			this.labelTask.Location = new System.Drawing.Point(12, 9);
-			this.labelTask.Name = "labelTask";
-			this.labelTask.Size = new System.Drawing.Size(344, 13);
-			this.labelTask.TabIndex = 1;
-			this.labelTask.Text = "labelTask";
-			// 
-			// labelStep
-			// 
-			this.labelStep.AutoEllipsis = true;
-			this.labelStep.Location = new System.Drawing.Point(12, 23);
-			this.labelStep.Name = "labelStep";
-			this.labelStep.Size = new System.Drawing.Size(344, 13);
-			this.labelStep.TabIndex = 2;
-			this.labelStep.Text = "labelStep";
-			// 
-			// buttonCancel
-			// 
-			this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.buttonCancel.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.buttonCancel.Location = new System.Drawing.Point(281, 68);
-			this.buttonCancel.Name = "buttonCancel";
-			this.buttonCancel.Size = new System.Drawing.Size(75, 23);
-			this.buttonCancel.TabIndex = 4;
-			this.buttonCancel.Text = "&Cancel";
-			this.buttonCancel.UseVisualStyleBackColor = true;
-			this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
-			// 
-			// ProgressDialog
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.CancelButton = this.buttonCancel;
+            this.progressBar.Margin = new System.Windows.Forms.Padding(3, 3, 6, 3);
+            this.progressBar.Maximum = 2147483646;
+            this.progressBar.Name = "progressBar";
+            this.progressBar.Size = new System.Drawing.Size(344, 23);
+            this.progressBar.Step = 1;
+            this.progressBar.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
+            this.progressBar.TabIndex = 3;
+            // 
+            // labelTask
+            // 
+            this.labelTask.AutoEllipsis = true;
+            this.labelTask.Location = new System.Drawing.Point(12, 9);
+            this.labelTask.Name = "labelTask";
+            this.labelTask.Size = new System.Drawing.Size(344, 13);
+            this.labelTask.TabIndex = 1;
+            this.labelTask.Text = "labelTask";
+            // 
+            // labelStep
+            // 
+            this.labelStep.AutoEllipsis = true;
+            this.labelStep.Location = new System.Drawing.Point(12, 23);
+            this.labelStep.Name = "labelStep";
+            this.labelStep.Size = new System.Drawing.Size(344, 13);
+            this.labelStep.TabIndex = 2;
+            this.labelStep.Text = "labelStep";
+            // 
+            // buttonCancel
+            // 
+            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonCancel.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.buttonCancel.Location = new System.Drawing.Point(281, 68);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(75, 23);
+            this.buttonCancel.TabIndex = 4;
+            this.buttonCancel.Text = "&Cancel";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            this.buttonCancel.Click += new System.EventHandler(this.buttonCancel_Click);
+            // 
+            // ProgressDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.buttonCancel;
             this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(368, 103);
-			this.ControlBox = false;
-			this.Controls.Add(this.buttonCancel);
-			this.Controls.Add(this.labelStep);
-			this.Controls.Add(this.labelTask);
-			this.Controls.Add(this.progressBar);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "ProgressDialog";
-			this.ShowIcon = false;
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "ProgressDialog";
-			this.Load += new System.EventHandler(this.ProgressDialog_Load);
-			this.ResumeLayout(false);
+            this.ControlBox = false;
+            this.Controls.Add(this.buttonCancel);
+            this.Controls.Add(this.labelStep);
+            this.Controls.Add(this.labelTask);
+            this.Controls.Add(this.progressBar);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "ProgressDialog";
+            this.ShowIcon = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "ProgressDialog";
+            this.Load += new System.EventHandler(this.ProgressDialog_Load);
+            this.ResumeLayout(false);
 
 		}
 

--- a/ModManagerCommon/Forms/ProgressDialog.Designer.cs
+++ b/ModManagerCommon/Forms/ProgressDialog.Designer.cs
@@ -33,12 +33,11 @@
 			this.labelStep = new System.Windows.Forms.Label();
 			this.buttonCancel = new System.Windows.Forms.Button();
 			this.SuspendLayout();
-			// 
-			// progressBar
-			// 
-			this.progressBar.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-			this.progressBar.Location = new System.Drawing.Point(12, 39);
+            // 
+            // progressBar
+            // 
+            this.progressBar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.progressBar.Location = new System.Drawing.Point(12, 39);
 			this.progressBar.Maximum = 2147483646;
 			this.progressBar.Name = "progressBar";
 			this.progressBar.Size = new System.Drawing.Size(344, 23);
@@ -82,7 +81,8 @@
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.CancelButton = this.buttonCancel;
-			this.ClientSize = new System.Drawing.Size(368, 103);
+            this.AutoSize = true;
+            this.ClientSize = new System.Drawing.Size(368, 103);
 			this.ControlBox = false;
 			this.Controls.Add(this.buttonCancel);
 			this.Controls.Add(this.labelStep);

--- a/ModManagerCommon/Forms/ProgressDialog.cs
+++ b/ModManagerCommon/Forms/ProgressDialog.cs
@@ -5,6 +5,14 @@ namespace ModManagerCommon.Forms
 {
 	public partial class ProgressDialog : Form
 	{
+		/// <summary>
+		/// Parameterless constructor to prevent the WinForms Editor from crashing on forms inheriting this one.
+		/// </summary>
+		public ProgressDialog()
+		{
+			InitializeComponent();
+		}
+
 		public event EventHandler CancelEvent;
 		#region Accessors
 

--- a/ModManagerCommon/ModManagerCommon.csproj
+++ b/ModManagerCommon/ModManagerCommon.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ModManagerCommon</RootNamespace>
     <AssemblyName>ModManagerCommon</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">


### PR DESCRIPTION
This pull request introduces the following changes:

- ModManagerCommon upgraded to .NET Framework 4.8. This will be necessary to upgrade the SADX Mod Manager.
- Fixed #11 by adding a parameterless form constructor. This does not affect any functionality and is simply a cosmetic fix to prevent the forms editor from crashing.
- Fixed a crash on cancelling a download. The crash happens because [the form is cast as `WebClient`](https://github.com/sonicretro/mod-loader-common/commit/4b61df8a29254418a2efbec3d101768829cbeec3#diff-df2b634dac65966afd89f2a888c802395c7fa8c89873c3ef2467ac68e90288b0L87).
- Fixed #10. The fix is a WinForms workaround that involves removing anchors to the right and bottom that prevent the form from resizing correctly at high DPI. The anchors are not required here anyway since the form isn't resizable. The progress bar's right margin was increased as well for cosmetic reasons. At 100% DPI the form looks the same as before. At 150% it looks like this:
Before
![image](https://user-images.githubusercontent.com/23312549/149510857-4e0eded4-163a-43da-aa0f-9714fb81f64a.png)
After
![image](https://user-images.githubusercontent.com/23312549/149510694-2ae50f0b-6510-4750-bf39-5b29a9ac26fd.png)
