### PR TITLE
Manifest-related cleanup

### DIFF
--- a/ModManagerCommon/NativeMethods.cs
+++ b/ModManagerCommon/NativeMethods.cs
@@ -10,30 +10,37 @@ namespace ModManagerCommon
 	{
 		private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
 
-		private const uint FILE_READ_EA = 0x0008;
+		private const uint FILE_READ_EA               = 0x0008;
 		private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x2000000;
 
 		[DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-		static extern uint GetFinalPathNameByHandle(IntPtr hFile, StringBuilder lpszFilePath, uint cchFilePath, uint dwFlags);
+		private static extern uint GetFinalPathNameByHandle(IntPtr hFile, IntPtr lpszFilePath, uint cchFilePath, uint dwFlags);
+
+		[DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+		private static extern uint GetFinalPathNameByHandle(IntPtr hFile, StringBuilder lpszFilePath, uint cchFilePath, uint dwFlags);
 
 		[DllImport("kernel32.dll", SetLastError = true)]
 		[return: MarshalAs(UnmanagedType.Bool)]
-		static extern bool CloseHandle(IntPtr hObject);
+		private static extern bool CloseHandle(IntPtr hObject);
 
 		[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-		private static extern IntPtr CreateFile(
-			string filename,
-			[MarshalAs(UnmanagedType.U4)] uint access,
-			[MarshalAs(UnmanagedType.U4)] FileShare share,
-			IntPtr securityAttributes,
-			[MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
-			[MarshalAs(UnmanagedType.U4)] uint flagsAndAttributes,
-			IntPtr templateFile);
+		private static extern IntPtr CreateFile(string filename,
+		                                        [MarshalAs(UnmanagedType.U4)] uint access,
+		                                        [MarshalAs(UnmanagedType.U4)] FileShare share,
+		                                        IntPtr securityAttributes,
+		                                        [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
+		                                        [MarshalAs(UnmanagedType.U4)] uint flagsAndAttributes,
+		                                        IntPtr templateFile);
 
 		public static string GetFinalPathName(string path)
 		{
-			IntPtr handle = CreateFile(path, FILE_READ_EA, FileShare.ReadWrite | FileShare.Delete, IntPtr.Zero,
-				FileMode.Open, FILE_FLAG_BACKUP_SEMANTICS, IntPtr.Zero);
+			IntPtr handle = CreateFile(path,
+			                           FILE_READ_EA,
+			                           FileShare.ReadWrite | FileShare.Delete,
+			                           IntPtr.Zero,
+			                           FileMode.Open,
+			                           FILE_FLAG_BACKUP_SEMANTICS,
+			                           IntPtr.Zero);
 
 			if (handle == INVALID_HANDLE_VALUE)
 			{
@@ -42,15 +49,48 @@ namespace ModManagerCommon
 
 			try
 			{
-				var sb = new StringBuilder(1024);
-				uint result = GetFinalPathNameByHandle(handle, sb, 1024, 0);
+				// First, call the function with no parameters to retrieve the character count
+				// of the reparsed name.
+				//
+				// Note that the count returned by this function, depending on Windows version
+				// and function version (A/W), may or may not include consideration for the
+				// null terminator.
+				uint requiredCount = GetFinalPathNameByHandle(handle, IntPtr.Zero, 0, 0);
 
-				if (result == 0)
+				if (requiredCount == 0)
 				{
 					throw new Win32Exception();
 				}
 
-				return sb.ToString();
+				// Given the odd null terminator behavior, we're being safe here and adding 1
+				// to the required capacity. We can't rely on the marhsalled StringBuilder to
+				// do the right thing (which *also* adds 1 for the null terminator).
+				int capacity = checked((int)(requiredCount + 1));
+				var sb = new StringBuilder(capacity);
+
+				uint finalCount = GetFinalPathNameByHandle(handle, sb, checked((uint)capacity), 0);
+
+				if (finalCount == 0)
+				{
+					throw new Win32Exception();
+				}
+
+				string result = sb.ToString();
+
+				// Manually handle the null terminator, if any.
+				int terminatorIndex = result.IndexOf('\0');
+
+				switch (terminatorIndex)
+				{
+					case -1:
+						return result;
+
+					case 0:
+						return string.Empty;
+
+					default:
+						return result.Substring(0, terminatorIndex);
+				}
 			}
 			finally
 			{


### PR DESCRIPTION
Most importantly, this PR rewrites `NativeMethods.GetFinalPathName` to remove arbitrary path length limits and ensure compatibility (related to null-terminator handling) with a wider range of Windows versions.